### PR TITLE
Emit all issues by default

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,12 +12,20 @@ To use, add a flog section to your .codeclimate.yml engines hash:
     engines:
       flog:
         enabled: true
+
+If you'd like the engine to only report issues for the most complex methods in
+your repo, you can set a threshold. For example:
+
+    engines:
+      flog:
+        enabled: true
         config:
           all: false
           threshold: 0.6
 
-You can either toggle :all to true (defaults to false) to report
-everything or tweak the reporting cutoff threshold (defaults to 60%).
+When configured like this, the engine will only emit issues for your most
+complex issues. Be aware that as you improve your most complex issues, new
+issues will show up for less complex issues.
 
 == REQUIREMENTS:
 

--- a/lib/cc/engine/flog.rb
+++ b/lib/cc/engine/flog.rb
@@ -21,7 +21,7 @@ module CC
 
       DEFAULTS = {
                   "include_paths" => ["."],
-                  "all"           => false, # users must opt-in
+                  "all"           => true, # users must opt-out
                  }
 
       def initialize(root, config = {}, io = STDOUT)
@@ -32,7 +32,7 @@ module CC
         options = {
                    :all       => config["all"],
                    :continue  => true,
-                   :threshold => config["threshold"] || 0.6,
+                   :threshold => config["threshold"]
                   }
 
         self.flog   = ::Flog.new options

--- a/test/test_sanity.rb
+++ b/test/test_sanity.rb
@@ -17,7 +17,7 @@ class TestSanity < Minitest::Test
 
   def assert_init exp_all, cfg = nil
     root = "."
-    exp = ["./lib/cc/engine/flog.rb", "./test/test_sanity.rb"]
+    exp = ["./test/test_sanity.rb", "./lib/cc/engine/flog.rb"]
     ccflog = CC::Engine::Flog.new(root, config(cfg))
     assert_equal exp_all, ccflog.config["all"]
     assert_equal exp, ccflog.files
@@ -26,20 +26,26 @@ class TestSanity < Minitest::Test
                 "include_paths" => ["."],
                 "all" => exp_all,
                }
-    assert_equal exp_conf, ccflog.config
 
+    if cfg && cfg["threshold"]
+      exp_conf.merge! "threshold" => cfg["threshold"].to_f
+    end
+
+    assert_equal exp_conf, ccflog.config
   end
 
   def test_initialize_cc_bugs
     # https://github.com/codeclimate/codeclimate-yaml/issues/38
     # https://github.com/codeclimate/codeclimate-yaml/issues/39
 
-    assert_init false                   # no config--expected and good
-    assert_init true,  "all" => true    # true config
+    assert_init true                    # no config--expected and good
+    assert_init false,  "all" => false  # false config
     assert_init true,  "all" => "true"  # buggy "true" config
     assert_init false, "all" => false   # false config
     assert_init false, "all" => "false" # buggy "false" config
-    assert_init false, ""               # buggy "" config
+    assert_init false, "all" => "false",
+      "threshold" => "0.8"              # buggy float config
+    assert_init true, ""                # buggy "" config
   end
 
   def test_run


### PR DESCRIPTION
The threshold feature can be confusing to users who aren't expecting
this behavior, because other engines emit all issues by default. It's a
little confusing to change one file, and then have issues show up in
another file. If a savvy user wants to enable this feature, they still
can.