### PR TITLE
QUA-1251: Update ruby_parser to 3.20.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gem "hoe"
 gem "minitest"
 gem "rake"
-gem "ruby_parser", "3.13.1"
-gem "flog", "~> 4.6"
+gem "ruby_parser", "3.20.0"
+gem "flog", "~> 4.6.6"
 
 group :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,28 +7,28 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
-    hoe (4.0.1)
+    hoe (4.0.3)
       rake (>= 0.8, < 15.0)
-    minitest (5.16.3)
+    minitest (5.18.0)
     path_expander (1.1.1)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.1)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.1)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby_parser (3.13.1)
-      sexp_processor (~> 4.9)
-    sexp_processor (4.16.1)
-    simplecov (0.21.2)
+    ruby_parser (3.20.0)
+      sexp_processor (~> 4.16)
+    sexp_processor (4.17.0)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -39,12 +39,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  flog (~> 4.6)
+  flog (~> 4.6.6)
   hoe
   minitest
   rake
   rspec
-  ruby_parser (= 3.13.1)
+  ruby_parser (= 3.20.0)
   simplecov
 
 BUNDLED WITH


### PR DESCRIPTION
This PR updates the ruby_parser to version 3.20.0, to support parsing of hash value omissions.

This fixes the issue presented in #15 